### PR TITLE
Enable the possibitlity of using DDLogFormatter's with TMDebugConsole

### DIFF
--- a/Classes/TMDebugConsole.h
+++ b/Classes/TMDebugConsole.h
@@ -18,7 +18,7 @@
 
 #import "DDLog.h"
 
-@interface TMDebugConsole : NSObject <DDLogger>
+@interface TMDebugConsole : DDAbstractLogger
 
 + (TMDebugConsole *)sharedInstance;
 


### PR DESCRIPTION
Mimic the behaviour of other DDLoggers that offer the possibility of attaching DDFormatters. This formatters can be used to preprocess messages or to filter them.