### PR TITLE
Display more messages and discard older messages instead of newer

### DIFF
--- a/Classes/TMDebugConsole.m
+++ b/Classes/TMDebugConsole.m
@@ -23,7 +23,7 @@ static TMDebugConsole *sharedInstance;
 static NSTimeInterval const kTMDebugConsoleMessageBufferingTime = 0.2;
 
 static NSUInteger const kTMDebugConsoleMaximumMessageLength = 512;
-static NSUInteger const kTMDebugConsoleMaximumMessages = 100;
+static NSUInteger const kTMDebugConsoleMaximumMessages = 1000;
 
 static CGFloat const kTMDebugConsoleBackgroundAlpha = 0.9f;
 
@@ -223,7 +223,7 @@ static NSString *const kTMDebugConsolePauseButtonContinue = @"Paused";
 
 	if (self.messages.count >= kTMDebugConsoleMaximumMessages)
 	{
-		NSRange messagesToDelete = NSMakeRange(kTMDebugConsoleMaximumMessages - 1, self.messages.count - kTMDebugConsoleMaximumMessages);
+		NSRange messagesToDelete = NSMakeRange(0, self.messages.count - kTMDebugConsoleMaximumMessages);
 		[self.messages removeObjectsInRange:messagesToDelete];
 	}
 


### PR DESCRIPTION
Enabling more messages in the debug console and making it discard older messages instead of newer messages.